### PR TITLE
JSDP.serialize: add toObject option

### DIFF
--- a/src/protocol/index.js
+++ b/src/protocol/index.js
@@ -4,8 +4,8 @@ import serializers from './serializers';
 let pluggableJSON = new PluggableJSON(serializers);
 
 export default {
-    serialize(obj) {
-        return pluggableJSON.serialize(obj);
+    serialize(obj, options) {
+        return pluggableJSON.serialize(obj, options);
     },
     deserialize(value) {
         return pluggableJSON.deserialize(value);

--- a/test/jsdp.spec.js
+++ b/test/jsdp.spec.js
@@ -13,4 +13,18 @@ describe('protocol', () => {
 
         expect(JSDP.deserialize(JSDP.serialize(obj))).to.deep.equal(obj);
     });
+
+    it('serializes and deserializes object to the same value (serializing to object)', () => {
+        const obj = {
+            aNaN: NaN,
+            anInfinity: Infinity,
+            aDate: new Date(2000),
+            aDuration: moment.duration(1, 'hour')
+        };
+
+        let serializedObject = JSDP.serialize(obj, { toObject: true });
+
+        expect(serializedObject).to.be.a('object');
+        expect(JSDP.deserialize(serializedObject)).to.deep.equal(obj);
+    });
 });


### PR DESCRIPTION
Sometimes (in outrigger) its useful to serialize to a JavaScript object instead of directly to a JSON string.

@mnibecker @mstemm 
