### PR TITLE
serializers: add Error

### DIFF
--- a/src/protocol/serializers/error-serializer.js
+++ b/src/protocol/serializers/error-serializer.js
@@ -1,0 +1,14 @@
+const errorSerializer = {
+    type: 'error',
+    isSerializable(value) {
+        return value instanceof Error;
+    },
+    serialize(value) {
+        return value.message;
+    },
+    deserialize(value) {
+        return new Error(value);
+    }
+};
+
+export default errorSerializer;

--- a/src/protocol/serializers/index.js
+++ b/src/protocol/serializers/index.js
@@ -1,11 +1,13 @@
 import dateSerializer from './date-serializer';
 import durationSerializer from './duration-serializer';
+import errorSerializer from './error-serializer';
 import nanSerializer from './nan-serializer';
 import infinitySerializer from './infinity-serializer';
 
 export default [
     dateSerializer,
     durationSerializer,
+    errorSerializer,
     infinitySerializer,
     nanSerializer
 ];

--- a/test/jsdp.spec.js
+++ b/test/jsdp.spec.js
@@ -19,12 +19,16 @@ describe('protocol', () => {
             aNaN: NaN,
             anInfinity: Infinity,
             aDate: new Date(2000),
+            error: new Error('hello'),
             aDuration: moment.duration(1, 'hour')
         };
 
         let serializedObject = JSDP.serialize(obj, { toObject: true });
-
         expect(serializedObject).to.be.a('object');
-        expect(JSDP.deserialize(serializedObject)).to.deep.equal(obj);
+
+        let deserializedObject = JSDP.deserialize(serializedObject);
+
+        expect(deserializedObject).to.deep.equal(obj);
+        expect(deserializedObject.error.message).equal('hello');
     });
 });


### PR DESCRIPTION
The Juttle Elastic Adapter does https://github.com/juttle/juttle-elastic-adapter/blob/master/lib/read.js#L171, and then the JSDP serializes the Error into an empty object, causing https://github.com/juttle/juttle-elastic-adapter/issues/109. The JSDP should serialize the Error into an Error.
@go-oleg 
