### PR TITLE
error serializer: serialize info and code too if present

### DIFF
--- a/src/protocol/serializers/error-serializer.js
+++ b/src/protocol/serializers/error-serializer.js
@@ -4,10 +4,33 @@ const errorSerializer = {
         return value instanceof Error;
     },
     serialize(value) {
-        return value.message;
+        var result = {
+            message: value.message
+        };
+
+        if (value.info) {
+            result.info = value.info;
+        }
+
+        if (value.code) {
+            result.code = value.code;
+        }
+
+        return JSON.stringify(result);
     },
     deserialize(value) {
-        return new Error(value);
+        var parsed = JSON.parse(value);
+        var err = new Error(parsed.message);
+
+        if (parsed.info) {
+            err.info = parsed.info;
+        }
+
+        if (parsed.code) {
+            err.code = parsed.code;
+        }
+
+        return err;
     }
 };
 

--- a/test/protocol/serializers/error-serializer.js
+++ b/test/protocol/serializers/error-serializer.js
@@ -1,0 +1,23 @@
+import ErrorSerializer from '../../../src/protocol/serializers/error-serializer';
+import { expect } from 'chai';
+
+describe('Error serializer', () => {
+    it('treats Error as serializable', () => {
+        expect(ErrorSerializer.isSerializable(new Error())).to.equal(true);
+    });
+
+    it('serializes and deserializes to Error', () => {
+        let err = new Error('this is the message');
+        err.info = { someInfo: 'a' };
+        err.code = 'SOME_ERROR';
+        let resultError = ErrorSerializer.deserialize(ErrorSerializer.serialize(err));
+
+        expect(resultError.message).to.equal(err.message);
+        expect(resultError.code).to.equal(err.code);
+        expect(resultError.info).to.deep.equal(err.info);
+    });
+
+    it('serializes to a string', () => {
+        expect(ErrorSerializer.serialize(new Error())).to.be.a('string');
+    });
+});


### PR DESCRIPTION
Building on top of https://github.com/juttle/juttle-jsdp/pull/8. Serialize info and code (used errors generated by juttle) as well if present.

@demmer @davidvgalbraith 
